### PR TITLE
feat: add swap variable to value and quick set variable context menu …

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Burp Variables is a Burp Suite extension designed to add variable storage and re
 * **Tool filtering:** Toggle which Burp tools perform variable replacement. By default, replacement is enabled for Repeater, Intruder, Scanner, and Extensions. Proxy replacement can be enabled only for in-scope requests.                                                                                                                                  
 * **Auto-update variables:** When enabled, variable values can be automatically updated from HTTP responses. Define a regex pattern with a capture group in the "Variable update regex" column and the first capture group match will become the new variable value.                                                                                      
 * **Import/Export:** Import and export variable data as CSV files to copy variables between projects.
+* **Swap variable to value:** Resolve all `((variableName))` references in the request editor to their current values via the right-click context menu. Useful for previewing the fully resolved request without sending it.
+* **Quick set variable:** Select any text in a request or response (in any Burp tool), right-click and choose "Quick set variable" to instantly create or update a variable with the selected text as its value. A confirmation dialog displays the result of the operation.
 
 ### Installation
 You can install this extension in one of two ways:
@@ -23,3 +25,9 @@ You can install this extension in one of two ways:
 3. Send the request and confirm that the variable references were replaced by viewing the request in the Logger tool:
 
    ![Viewing request with replaced references in Logger tool](burp_variables3.png)
+
+### Context Menu
+Right-click in any message editor or viewer to access Burp Variables features:
+* **Insert variable** — Insert a `((variableName))` reference at the caret position or replace the selected text (available in request editors).
+* **Swap variable to value** — Replace all variable references in the request with their resolved values (available in request editors).
+* **Quick set variable** — Create or update a variable from selected text in any request or response viewer/editor across all Burp tools.

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.0xceba'
-version '1.2.0'
+version '1.3.0'
 
 repositories {
     mavenLocal()

--- a/src/main/java/com/_0xceba/BurpVariablesContextMenuProvider.java
+++ b/src/main/java/com/_0xceba/BurpVariablesContextMenuProvider.java
@@ -10,57 +10,66 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.swing.*;
 
 /**
  * Context menu provider to add menu items for inserting variables at
- * the user's caret.
+ * the user's caret, swapping variable references to their resolved values,
+ * and quickly creating or updating variables from selected text.
  */
 public class BurpVariablesContextMenuProvider implements ContextMenuItemsProvider {
     private final Logging burpLogging;
     private final HashMap<String, VariableData> variablesMap;
+    private final BurpVariablesTab variablesTab;
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\(\\(.+?\\)\\)");
 
     /**
      * Constructs a new context menu provider.
      *
      * @param burpLogging   The logging interface from the Montoya API.
      * @param variablesMap  HashMap storing variable names and VariableData.
+     * @param variablesTab  The Variables tab for creating/updating variables from the context menu.
      */
-    public BurpVariablesContextMenuProvider(Logging burpLogging, HashMap<String, VariableData> variablesMap) {
+    public BurpVariablesContextMenuProvider(Logging burpLogging, HashMap<String, VariableData> variablesMap, BurpVariablesTab variablesTab) {
         this.burpLogging = burpLogging;
         this.variablesMap = variablesMap;
+        this.variablesTab = variablesTab;
     }
 
     /**
-     * Generates and returns a list of context menu items for each variable if
-     * the context menu is executed against a message editor request. The menu
-     * items insert the selected variable key.
+     * Generates and returns a list of context menu items based on the invocation context.
+     * <ul>
+     *   <li>MESSAGE_EDITOR_REQUEST: Insert variable, Swap variable to value, Quick set variable</li>
+     *   <li>All other message editor/viewer contexts: Quick set variable (when text is selected)</li>
+     * </ul>
      *
      * @param contextMenuEvent  The event that triggered the context menu.
      * @return  A list of the context menu items to be added to the menu.
      */
     @Override
     public List<Component> provideMenuItems(ContextMenuEvent contextMenuEvent) {
-        // Check if the event originated from MESSAGE_EDITOR_REQUEST
-        if(contextMenuEvent.messageEditorRequestResponse().isPresent()
-                && contextMenuEvent.isFrom(InvocationType.MESSAGE_EDITOR_REQUEST)) {
+        // Only provide items when a message editor or viewer is present
+        if (!contextMenuEvent.messageEditorRequestResponse().isPresent()) {
+            return null;
+        }
 
-            // Return null if no variables are defined to avoid an empty context menu
-            if (variablesMap.isEmpty()) {
-                return null;
-            }
+        List<Component> contextMenuProviderList = new ArrayList<>();
 
-            // List of context menu items to be returned
-            List<Component> contextMenuProviderList = new ArrayList<>();
-
+        // --- Insert variable and Swap: only for MESSAGE_EDITOR_REQUEST ---
+        if (contextMenuEvent.isFrom(InvocationType.MESSAGE_EDITOR_REQUEST) && !variablesMap.isEmpty()) {
             // Sort variablesMap keys alphabetically
             List<String> sortedVariablesMapKeys = new ArrayList<>(variablesMap.keySet());
             Collections.sort(sortedVariablesMapKeys);
 
+            // --- "Insert variable" sub-menu ---
+            JMenu insertMenu = new JMenu("Insert variable");
+
             // Iterate through sorted variablesMap keys
             for(String variableKey : sortedVariablesMapKeys) {
                 // Create a new JMenuItem with the label containing the variablesMap key
-                JMenuItem contextMenuItem = new JMenuItem("Insert ((" + variableKey + "))");
+                JMenuItem contextMenuItem = new JMenuItem("((" + variableKey + "))");
 
                 // Add an action listener to handle user interaction
                 contextMenuItem.addActionListener(e -> {
@@ -97,13 +106,118 @@ public class BurpVariablesContextMenuProvider implements ContextMenuItemsProvide
                     // Set the modified request in the message editor
                     messageEditor.setRequest(modifiedRequest);
                 });
-                // Add the context menu item to the provider list
-                contextMenuProviderList.add(contextMenuItem);
+                // Add the context menu item to the insert sub-menu
+                insertMenu.add(contextMenuItem);
             }
-            // Return the context menu provider list
-            return contextMenuProviderList;
-        } else {
-            return null;
+            contextMenuProviderList.add(insertMenu);
+
+            // --- "Swap variable to value" menu item ---
+            // Resolves ((variableName)) references in the request to their actual values.
+            // This is the reverse of what the HTTP handler does at send-time, letting the
+            // user preview the resolved request directly in the editor.
+            JMenuItem swapVariableToValueItem = new JMenuItem("Swap variable to value");
+
+            swapVariableToValueItem.addActionListener(e -> {
+                MessageEditorHttpRequestResponse messageEditor = contextMenuEvent.messageEditorRequestResponse().get();
+                String requestString = messageEditor.requestResponse().request().toString();
+
+                // Replace all ((variableName)) references with their resolved values
+                String modifiedRequestString = resolveVariables(requestString);
+
+                // Only update the request if replacements were made
+                if (!modifiedRequestString.equals(requestString)) {
+                    HttpService requestService = messageEditor.requestResponse().request().httpService();
+                    HttpRequest modifiedRequest = HttpRequest.httpRequest(requestService, modifiedRequestString);
+                    messageEditor.setRequest(modifiedRequest);
+                }
+            });
+            contextMenuProviderList.add(swapVariableToValueItem);
         }
+
+        // --- "Quick set variable" menu item ---
+        // Available in any message editor/viewer context when text is selected.
+        // Creates a new variable or updates an existing one with the selected text as the value.
+        MessageEditorHttpRequestResponse messageEditor = contextMenuEvent.messageEditorRequestResponse().get();
+        if (messageEditor.selectionOffsets().isPresent()) {
+            JMenuItem quickSetItem = new JMenuItem("Quick set variable");
+
+            quickSetItem.addActionListener(e -> {
+                // Determine the displayed message based on the invocation context
+                String displayedMessage;
+                if (contextMenuEvent.isFrom(
+                        InvocationType.MESSAGE_EDITOR_REQUEST,
+                        InvocationType.MESSAGE_VIEWER_REQUEST)) {
+                    displayedMessage = messageEditor.requestResponse().request().toString();
+                } else {
+                    if (messageEditor.requestResponse().response() == null) {
+                        return;
+                    }
+                    displayedMessage = messageEditor.requestResponse().response().toString();
+                }
+
+                // Extract the selected text using selection offsets
+                int startIndex = messageEditor.selectionOffsets().get().startIndexInclusive();
+                int endIndex = messageEditor.selectionOffsets().get().endIndexExclusive();
+                String selectedText = displayedMessage.substring(startIndex, endIndex);
+
+                // Prompt the user for the variable name
+                String variableName = (String) JOptionPane.showInputDialog(
+                        SwingUtilities.getWindowAncestor(variablesTab),
+                        "Selected value: " + (selectedText.length() > 80
+                                ? selectedText.substring(0, 80) + "..."
+                                : selectedText)
+                                + "\n\nVariable name:",
+                        "Quick set variable",
+                        JOptionPane.PLAIN_MESSAGE,
+                        null, null,
+                        null);
+
+                // Create or update the variable if the user provided a name
+                if (variableName != null && !variableName.trim().isEmpty()) {
+                    String result = variablesTab.addOrUpdateVariable(variableName.trim(), selectedText);
+                    boolean isSuccess = result.contains("successfully");
+                    JOptionPane.showMessageDialog(
+                            SwingUtilities.getWindowAncestor(variablesTab),
+                            result,
+                            "Quick set variable",
+                            isSuccess ? JOptionPane.INFORMATION_MESSAGE : JOptionPane.ERROR_MESSAGE);
+                }
+            });
+            contextMenuProviderList.add(quickSetItem);
+        }
+
+        // Return the list or null if no items were added
+        return contextMenuProviderList.isEmpty() ? null : contextMenuProviderList;
+    }
+
+    /**
+     * Replaces each ((variableName)) reference in the given string with the
+     * variable's current value from the variables map. References whose key
+     * is not found in the map are left unchanged.
+     *
+     * @param input The string containing variable references.
+     * @return The string with variable references resolved to their values.
+     */
+    private String resolveVariables(String input) {
+        Matcher matcher = VARIABLE_PATTERN.matcher(input);
+        StringBuilder result = new StringBuilder();
+
+        while (matcher.find()) {
+            // Extract the variable name from between (( and ))
+            String match = matcher.group();
+            String variableName = match.substring(2, match.length() - 2);
+
+            // Look up the variable in the map; if found replace with value, otherwise keep as-is
+            VariableData variableData = variablesMap.get(variableName);
+            if (variableData != null && !variableData.value().isEmpty()) {
+                // Use Matcher.quoteReplacement to handle special characters (e.g. $ and \) in values
+                matcher.appendReplacement(result, Matcher.quoteReplacement(variableData.value()));
+            } else {
+                matcher.appendReplacement(result, Matcher.quoteReplacement(match));
+            }
+        }
+        matcher.appendTail(result);
+
+        return result.toString();
     }
 }

--- a/src/main/java/com/_0xceba/BurpVariablesEntry.java
+++ b/src/main/java/com/_0xceba/BurpVariablesEntry.java
@@ -72,7 +72,7 @@ public class BurpVariablesEntry implements BurpExtension {
         montoyaApi.http().registerHttpHandler(new BurpVariablesHTTPHandler(burpLogging, variablesMap, toolsEnabledMap, variablesTab));
 
         // Register a context menu provider to add items to the context menu
-        montoyaApi.userInterface().registerContextMenuItemsProvider(new BurpVariablesContextMenuProvider(burpLogging, variablesMap));
+        montoyaApi.userInterface().registerContextMenuItemsProvider(new BurpVariablesContextMenuProvider(burpLogging, variablesMap, variablesTab));
 
         // Log initialization output
         String version = getClass().getPackage().getImplementationVersion();

--- a/src/main/java/com/_0xceba/BurpVariablesTab.java
+++ b/src/main/java/com/_0xceba/BurpVariablesTab.java
@@ -936,4 +936,36 @@ public class BurpVariablesTab extends JPanel {
             }
         });
     }
+
+    /**
+     * Creates a new variable or updates an existing variable's value.
+     * This method is intended to be called from the context menu's "Quick set variable" action.
+     * When updating, the existing regex pattern is preserved.
+     *
+     * @param variableName  The name of the variable.
+     * @param variableValue The value to assign to the variable.
+     * @return A result message indicating the outcome: created, updated, or failed.
+     */
+    public String addOrUpdateVariable(String variableName, String variableValue) {
+        if (variableName == null || variableName.isEmpty()) {
+            return "Variable name cannot be empty.";
+        }
+
+        if (variablesMap.containsKey(variableName)) {
+            // Update existing variable value, preserving the regex pattern
+            String existingRegex = variablesMap.get(variableName).regex();
+            variablesMap.put(variableName, new VariableData(variableValue, existingRegex));
+            updateVariableInTable(variableName, variableValue);
+            burpLogging.logToOutput("Updated variable '" + variableName + "' via quick set.");
+            return "Variable '" + variableName + "' updated successfully.";
+        } else {
+            // Create a new variable with an empty regex
+            if (addVariable(variableName, variableValue, "")) {
+                burpLogging.logToOutput("Created variable '" + variableName + "' via quick set.");
+                return "Variable '" + variableName + "' created successfully.";
+            } else {
+                return "Failed to create variable '" + variableName + "'.";
+            }
+        }
+    }
 }


### PR DESCRIPTION
…actions

- Add 'Swap variable to value' context menu item that resolves all ((variableName)) references in the request editor to their current values, allowing users to preview the fully resolved request.

- Add 'Quick set variable' context menu item available across all Burp tools (Repeater, Proxy, Intruder, etc.) in both request and response editors/viewers. Select any text, right-click, and instantly create or update a variable with the selected text as its value. Displays a success/failure confirmation dialog.

- Reorganize context menu: Insert variable items are now grouped under an 'Insert variable' sub-menu for cleaner organization.

- Add addOrUpdateVariable() public API to BurpVariablesTab for programmatic variable creation/update from external callers.

- Bump version to 1.3.0
- Update README with new feature documentation and Context Menu section